### PR TITLE
Update to work with newer NewRelic format

### DIFF
--- a/fluent.conf
+++ b/fluent.conf
@@ -13,8 +13,8 @@
 ## match events whose tag is newrelic.** and send to New Relic
 <match newrelic.**>
   @type newrelic
-  api_key "#{ENV['NR_API_KEY']}"
-  use_ssl true
+  license_key "#{ENV['NR_API_KEY']}"
+  base_uri https://log-api.newrelic.com/log/v1
   <buffer>
     @type file
     path ./buffer/newrelic


### PR DESCRIPTION
I tried the original and it didn't work and returned 403s on trying to forward logs to NewRelic. But I was able to infer the following format from the example they give in the setup wizard. With this change it works great for me!